### PR TITLE
Corrected link to the Github repository of CS407

### DIFF
--- a/Intro.md
+++ b/Intro.md
@@ -4,7 +4,7 @@ Course Syllabus for "CS407: Network Applications Development"
 **Please note: this [legacy course](https://sayloracademy.zendesk.com/hc/en-us/articles/206089967) does not offer a certificate and may contain 
 broken links and outdated information.** Although archived, it is open 
 for learning without registration or enrollment. Please consider contributing 
-updates to [this course on GitHub](https://github.com/saylordotorg/course_comm407) 
+updates to [this course on GitHub](https://github.com/saylordotorg/course_cs407) 
 (you can also adopt, adapt, and distribute this course under the terms of 
 the [Creative Commons Attribution 3.0 license](http://creativecommons.org/licenses/by/3.0/)). **To find fully-supported, current courses, [visit our 
 Learn site](https://learn.saylor.org).**


### PR DESCRIPTION
Corrected hyperlink that was wrongly pointing to https://github.com/saylordotorg/course_comm407 and that should be pointing instead to https://github.com/saylordotorg/course_cs407